### PR TITLE
fix: Disable Nunjucks

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ hexo.config.markdown.render = Object.assign({
 
 const renderer = require('./lib/renderer')
 
+renderer.disableNunjucks = true
+
 hexo.extend.renderer.register('md', 'html', renderer, true)
 hexo.extend.renderer.register('markdown', 'html', renderer, true)
 hexo.extend.renderer.register('mkd', 'html', renderer, true)


### PR DESCRIPTION
由於 Nunjucks 標籤 {{ }} 或 {% %} 會影響渲染功能，且渲染已由本套件完成，故將其關閉


參考文件: [禁用 Nunjucks 标签](https://hexo.io/zh-cn/api/renderer.html#%E7%A6%81%E7%94%A8-Nunjucks-%E6%A0%87%E7%AD%BE)