### PR TITLE
fix: minimatch is not a function

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -17,7 +17,7 @@ function check_exclude (path, exclude) {
   if (path && exclude && exclude.length) {
     let i = 0; const len = exclude.length
     for (; i < len; i++) {
-      if (minimatch(path, exclude[i], { matchBase: true })) return true
+      if (minimatch.minimatch(path, exclude[i], { matchBase: true })) return true
     }
   } else return false
 }


### PR DESCRIPTION
fix https://github.com/theme-shoka-x/hexo-theme-shokaX/issues/109
also see [issue](https://stackoverflow.com/questions/76049247/typeerror-minimatch-is-not-a-function-error-when-running-new-expo-project)