### PR TITLE
Revert "fix: Disable Nunjucks"

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ hexo.config.markdown.render = Object.assign({
 
 const renderer = require('./lib/renderer')
 
-renderer.disableNunjucks = true
-
 hexo.extend.renderer.register('md', 'html', renderer, true)
 hexo.extend.renderer.register('markdown', 'html', renderer, true)
 hexo.extend.renderer.register('mkd', 'html', renderer, true)


### PR DESCRIPTION
Reverts theme-shoka-x/hexo-renderer-multi-next-markdown-it#9
根据用户反馈，此修改可能导致hexo tag无法渲染